### PR TITLE
Remove deprecated MUI v4 imports and replace them with MUI v5 compatible alternatives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoqa/carousel",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "index.js",
   "module": "es/index.js",
   "types": "index.d.ts",
@@ -18,7 +18,7 @@
     "react-swipeable-views-utils": "0.13.9"
   },
   "devDependencies": {
-    "@material-ui/core": "4.11.3",
+    "@material-ui/core": "4.11.3-deprecations.1",
     "@material-ui/icons": "4.11.2",
     "@testing-library/jest-dom": "5.11.9",
     "@testing-library/react": "11.2.3",

--- a/src/Gallery.tsx
+++ b/src/Gallery.tsx
@@ -6,8 +6,8 @@ import {
   useCarouselContext,
 } from './carousel';
 import {
-  GridList,
-  GridListTile,
+  ImageList,
+  ImageListItem,
   makeStyles,
   useMediaQuery,
   useTheme,
@@ -69,13 +69,13 @@ export function Gallery({ slides, title }: GalleryProps) {
       translationsFactory={getDefaultTranslations}
     >
       <h2>{title}</h2>
-      <GridList cols={isMobile ? 1 : 3}>
+      <ImageList cols={isMobile ? 1 : 3}>
         {slides.map((slide, index) => (
-          <GridListTile key={index}>
+          <ImageListItem key={index}>
             <ClickableImage index={index} {...slide} />
-          </GridListTile>
+          </ImageListItem>
         ))}
-      </GridList>
+      </ImageList>
       <CarouselWithModal title={title} />
     </CarouselContextProvider>
   );

--- a/src/carousel/CarouselControls.tsx
+++ b/src/carousel/CarouselControls.tsx
@@ -1,6 +1,6 @@
 import React, { MouseEvent, MouseEventHandler } from 'react';
 import {
-  fade,
+  alpha,
   Fade,
   IconButton,
   makeStyles,
@@ -30,9 +30,9 @@ const useStyles = /*#__PURE__*/ makeStyles((theme) => ({
     marginLeft: theme.spacing(2),
     marginRight: theme.spacing(2),
     color: 'white',
-    backgroundColor: fade('#000000', 0.6),
+    backgroundColor: alpha('#000000', 0.6),
     '&:hover': {
-      backgroundColor: fade('#000000', 0.8),
+      backgroundColor: alpha('#000000', 0.8),
     },
   },
 }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,14 +1395,14 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@material-ui/core@4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.3.tgz#f22e41775b0bd075e36a7a093d43951bf7f63850"
-  integrity sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==
+"@material-ui/core@4.11.3-deprecations.1":
+  version "4.11.3-deprecations.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.3-deprecations.1.tgz#e7accb3f4b8006ffe3f7a0070ca8dda6fc4101e4"
+  integrity sha512-uM/yQkCnRiKBacq39vLb0vcBe7aXeDIzA/Ml3dNlXKGw6/DoWmbMSaNr5kCSpe2bqsqNIRxaqlraT65IGBVW8A==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/styles" "^4.11.3"
-    "@material-ui/system" "^4.11.3"
+    "@material-ui/styles" "4.11.3-deprecations.1"
+    "@material-ui/system" "4.11.3-deprecations.1"
     "@material-ui/types" "^5.1.0"
     "@material-ui/utils" "^4.11.2"
     "@types/react-transition-group" "^4.2.0"
@@ -1420,10 +1420,10 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
-"@material-ui/styles@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz#1b8d97775a4a643b53478c895e3f2a464e8916f2"
-  integrity sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==
+"@material-ui/styles@4.11.3-deprecations.1":
+  version "4.11.3-deprecations.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3-deprecations.1.tgz#32590cd4d478b67839095458137e1db167a182b8"
+  integrity sha512-SXbKJPUZ/VnEGJhflnHlhpLkIYLlG/4FTN0Wlsw44PrAhIu5ZsQERix5yEzzv3rJI+8YRLS0LzPzjmTwGrCMNw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/hash" "^0.8.0"
@@ -1442,10 +1442,10 @@
     jss-plugin-vendor-prefixer "^10.5.1"
     prop-types "^15.7.2"
 
-"@material-ui/system@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3.tgz#466bc14c9986798fd325665927c963eb47cc4143"
-  integrity sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==
+"@material-ui/system@4.11.3-deprecations.1":
+  version "4.11.3-deprecations.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3-deprecations.1.tgz#ff0f3e8256a1dad16c385645698093499a8d513d"
+  integrity sha512-TZ0xnYYtltjinw0Ie2I/EXHOMmluVV/xrKNN9VEFxQOui1GR+5ypMCptFYbV8lYb5AnTuzHQeDGJpP+K/EEMpg==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/utils" "^4.11.2"


### PR DESCRIPTION
Pour préparer la migration vers MUI v5.